### PR TITLE
Fix for floating point crashes and warnings for gcc 12

### DIFF
--- a/basic_circuit.cc
+++ b/basic_circuit.cc
@@ -899,20 +899,20 @@ double shortcircuit(
     double vdd)
 {
 
-	double p_short_circuit=0, p_short_circuit_discharge=0;//, p_short_circuit_charge, p_short_circuit_discharge_low, p_short_circuit_discharge_high, p_short_circuit_charge_low, p_short_circuit_charge_high; //this is actually energy
-	double /*fo_n,*/ fo_p, fanout, beta_ratio /*,vt_to_vdd_ratio*/;
-	double f_alpha, k_v, e, g_v_alpha, h_v_alpha;
+	double p_short_circuit=0;//, p_short_circuit_discharge=0, p_short_circuit_charge, p_short_circuit_discharge_low, p_short_circuit_discharge_high, p_short_circuit_charge_low, p_short_circuit_charge_high; //this is actually energy
+	//double /*fo_n,*/ fo_p, fanout, beta_ratio /*,vt_to_vdd_ratio*/;
+	//double f_alpha, k_v, e, g_v_alpha, h_v_alpha;
 
 	///fo_n		= i_on_n/i_on_n_in;
-	fo_p		= i_on_p/i_on_p_in;
-	fanout		= 1;
-	beta_ratio 	= i_on_p/i_on_n;
+	//fo_p		= i_on_p/i_on_p_in;
+	//fanout		= 1;
+	//beta_ratio 	= i_on_p/i_on_n;
 	///vt_to_vdd_ratio = vt/vdd;
-	e 			= 	2.71828;
-	f_alpha		=	1/(velocity_index+2) -velocity_index/(2*(velocity_index+3)) +velocity_index/(velocity_index+4)*(velocity_index/2-1);
-	k_v			=	0.9/0.8+(vdd-vt)/0.8*log(10*(vdd-vt)/e);
-	g_v_alpha	=	(velocity_index + 1)*pow((1-velocity_index),velocity_index)*pow((1-velocity_index),velocity_index/2)/f_alpha/pow((1-velocity_index-velocity_index),(velocity_index/2+velocity_index+2));
-	h_v_alpha	=   pow(2, velocity_index)*(velocity_index+1)*pow((1-velocity_index),velocity_index)/pow((1-velocity_index-velocity_index),(velocity_index+1));
+	//e 			= 	2.71828;
+	//f_alpha		=	1/(velocity_index+2) -velocity_index/(2*(velocity_index+3)) +velocity_index/(velocity_index+4)*(velocity_index/2-1);
+	//k_v			=	0.9/0.8+(vdd-vt)/0.8*log(10*(vdd-vt)/e);
+	//g_v_alpha	=	(velocity_index + 1)*pow((1-velocity_index),velocity_index)*pow((1-velocity_index),velocity_index/2)/f_alpha/pow((1-velocity_index-velocity_index),(velocity_index/2+velocity_index+2));
+	//h_v_alpha	=   pow(2, velocity_index)*(velocity_index+1)*pow((1-velocity_index),velocity_index)/pow((1-velocity_index-velocity_index),(velocity_index+1));
 
 	//p_short_circuit_discharge_low 	= 10/3*(pow(0.5-vt_to_vdd_ratio,3.0)/pow(velocity_index,2.0)/pow(2.0,3*vt_to_vdd_ratio*vt_to_vdd_ratio))*c_in*vdd*vdd*fo_p*fo_p/fanout/beta_ratio;
 //	p_short_circuit_discharge_low 	= 10/3*(pow(((vdd-vt)-vt_to_vdd_ratio),3.0)/pow(velocity_index,2.0)/pow(2.0,3*vt_to_vdd_ratio*vt_to_vdd_ratio))*c_in*vdd*vdd*fo_p*fo_p/fanout/beta_ratio;
@@ -936,7 +936,7 @@ double shortcircuit(
 //
 //	p_short_circuit = p_short_circuit_discharge;
 
-	p_short_circuit_discharge = k_v*vdd*vdd*c_in*fo_p*fo_p/((vdd-vt)*g_v_alpha*fanout*beta_ratio/2/k_v + h_v_alpha*fo_p);
+	//p_short_circuit_discharge = k_v*vdd*vdd*c_in*fo_p*fo_p/((vdd-vt)*g_v_alpha*fanout*beta_ratio/2/k_v + h_v_alpha*fo_p);
   return (p_short_circuit);
 }
 

--- a/cacti.mk
+++ b/cacti.mk
@@ -13,7 +13,7 @@ INCS = -lm
 
 ifeq ($(TAG),dbg)
   DBG = -Wall 
-  OPT = -ggdb -g -O0 -DNTHREADS=1  -gstabs+
+  OPT = -ggdb -g -O0 -DNTHREADS=1
 else
   DBG = 
   OPT = -g  -msse2 -mfpmath=sse -DNTHREADS=$(NTHREADS)

--- a/crossbar.cc
+++ b/crossbar.cc
@@ -143,7 +143,7 @@ void Crossbar::compute_power()
   double cap = g_tp.wire_outside_mat.C_per_um * (area.w + area.h) + n_out*tri_inp_cap + n_inp*tri_out_cap;
   delay = horowitz(w1.signal_rise_time(), res*cap, deviceType->Vth/deviceType->Vdd, deviceType->Vth/deviceType->Vdd, RISE);
 
-  Wire wreset();
+  Wire wreset;
 }
 
 void Crossbar::print_crossbar()

--- a/extio.cc
+++ b/extio.cc
@@ -500,7 +500,7 @@ void Extio::extio_eye()
 
 	printf("IO Timing Margin (ps) = ");
 	cout << io_tmargin <<endl;
-	printf("IO Votlage Margin (V) = ");
+	printf("IO Voltage Margin (V) = ");
 	cout << io_vmargin << endl;
 
 }

--- a/extio_technology.cc
+++ b/extio_technology.cc
@@ -268,9 +268,9 @@ int IOTechParam::frequnecy_index(Mem_IO_type type)
 
 IOTechParam::IOTechParam(InputParameter * g_ip) 
 {
-  num_mem_ca  = g_ip->num_mem_dq * (g_ip->num_dq/g_ip->mem_data_width); 
+  num_mem_ca  = g_ip->num_mem_dq * ((double)g_ip->num_dq/g_ip->mem_data_width); 
   num_mem_clk =  g_ip->num_mem_dq *
-                (g_ip->num_dq/g_ip->mem_data_width)/(g_ip->num_clk/2); 
+                ((double)g_ip->num_dq/g_ip->mem_data_width)/((double)g_ip->num_clk/2); 
 
 
   if (g_ip->io_type == LPDDR2) { //LPDDR
@@ -354,16 +354,16 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
     k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/34 - 1) +
-        0.2*(g_ip->num_mem_dq/2 - 1));
+        0.2*((double)g_ip->num_mem_dq/2 - 1));
     k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/34 - 1) +
-        0.2*(g_ip->num_mem_dq/2 - 1));
+        0.2*((double)g_ip->num_mem_dq/2 - 1));
     k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/100 - 1) +
         0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
 
     t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/34 - 1) +
-        0.3*(g_ip->num_mem_dq/2 - 1));
+        0.3*((double)g_ip->num_mem_dq/2 - 1));
     t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/34 - 1) +
-        0.3*(g_ip->num_mem_dq/2 - 1));
+        0.3*((double)g_ip->num_mem_dq/2 - 1));
     t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/100 - 1) +
         0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
     t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.2*(rtt_ca/100 - 1) +
@@ -483,17 +483,17 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
      k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*(g_ip->num_mem_dq/2 - 1));
+         0.2*((double)g_ip->num_mem_dq/2 - 1));
      k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*(g_ip->num_mem_dq/2 - 1));
+         0.2*((double)g_ip->num_mem_dq/2 - 1));
      k_noise_addr_sen = k_noise_addr * (1 + 0.2*(r_on/50 - 1) + 
          0.2*(num_mem_ca/16 - 1));
 
 
      t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/50 - 1) + 
-         0.3*(g_ip->num_mem_dq/2 - 1));
+         0.3*((double)g_ip->num_mem_dq/2 - 1));
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/50 - 1) + 
-         0.3*(g_ip->num_mem_dq/2 - 1));
+         0.3*((double)g_ip->num_mem_dq/2 - 1));
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.1*(r_on/50 - 1) + 
          0.4*(num_mem_ca/16 - 1));
      t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.1*(r_on/50 - 1) + 
@@ -614,11 +614,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(g_ip->num_mem_dq/2 - 1));
+         0.2*((double)g_ip->num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(g_ip->num_mem_dq/2 - 1));
+         0.2*((double)g_ip->num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -626,11 +626,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*(g_ip->num_mem_dq/2 - 1));
+         0.3*((double)g_ip->num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*(g_ip->num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*((double)g_ip->num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -752,11 +752,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(g_ip->num_mem_dq/2 - 1));
+         0.2*((double)g_ip->num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(g_ip->num_mem_dq/2 - 1));
+         0.2*((double)g_ip->num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -764,11 +764,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*(g_ip->num_mem_dq/2 - 1));
+         0.3*((double)g_ip->num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*(g_ip->num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*((double)g_ip->num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -829,6 +829,8 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
      t_soc_hold = 10; 
      t_jitter_setup = 20; 
      t_jitter_hold = 20;
+     t_jitter_addr_setup = 40; //SET THIS VAR TO A DEFAULT NUMBER TO AVOID UNDEFINED BEHAVIOUR. THIS NUMBER IS PROBABLY INCORRECT.
+     t_jitter_addr_hold = 40; //SET THIS VAR TO A DEFAULT NUMBER TO AVOID UNDEFINED BEHAVIOUR. THIS NUMBER IS PROBABLY INCORRECT.
 
      //External IO Configuration Parameters 
 
@@ -915,7 +917,7 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 {
   num_mem_ca  = num_mem_dq * (mem_data_width); 
   num_mem_clk =  num_mem_dq *
-                (num_dq/mem_data_width)/(g_ip->num_clk/2); 
+                ((double)num_dq/mem_data_width)/((double)g_ip->num_clk/2); 
 
   io_type = io_type1;
   frequency = freq;
@@ -1004,16 +1006,16 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
     k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/34 - 1) +
-        0.2*(num_mem_dq/2 - 1));
+        0.2*((double)num_mem_dq/2 - 1));
     k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/34 - 1) +
-        0.2*(num_mem_dq/2 - 1));
+        0.2*((double)num_mem_dq/2 - 1));
     k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/100 - 1) +
         0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
 
     t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/34 - 1) +
-        0.3*(num_mem_dq/2 - 1));
+        0.3*((double)num_mem_dq/2 - 1));
     t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/34 - 1) +
-        0.3*(num_mem_dq/2 - 1));
+        0.3*((double)num_mem_dq/2 - 1));
     t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/100 - 1) +
         0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
     t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.2*(rtt_ca/100 - 1) +
@@ -1133,17 +1135,17 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
      k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*(num_mem_dq/2 - 1));
+         0.2*((double)num_mem_dq/2 - 1));
      k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*(num_mem_dq/2 - 1));
+         0.2*((double)num_mem_dq/2 - 1));
      k_noise_addr_sen = k_noise_addr * (1 + 0.2*(r_on/50 - 1) + 
          0.2*(num_mem_ca/16 - 1));
 
 
      t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/50 - 1) + 
-         0.3*(num_mem_dq/2 - 1));
+         0.3*((double)num_mem_dq/2 - 1));
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/50 - 1) + 
-         0.3*(num_mem_dq/2 - 1));
+         0.3*((double)num_mem_dq/2 - 1));
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.1*(r_on/50 - 1) + 
          0.4*(num_mem_ca/16 - 1));
      t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.1*(r_on/50 - 1) + 
@@ -1292,11 +1294,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(num_mem_dq/2 - 1));
+         0.2*((double)num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(num_mem_dq/2 - 1));
+         0.2*((double)num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -1304,11 +1306,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*(num_mem_dq/2 - 1));
+         0.3*((double)num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*(num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*((double)num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -1457,11 +1459,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(num_mem_dq/2 - 1));
+         0.2*((double)num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*(num_mem_dq/2 - 1));
+         0.2*((double)num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -1469,11 +1471,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*(num_mem_dq/2 - 1));
+         0.3*((double)num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*(num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*((double)num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -1534,6 +1536,10 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
      t_soc_hold = 10; 
      t_jitter_setup = 20; 
      t_jitter_hold = 20;
+     t_jitter_addr_setup = 40; //SET THIS VAR TO A DEFAULT NUMBER TO AVOID UNDEFINED BEHAVIOUR. THIS NUMBER IS PROBABLY INCORRECT.
+     t_jitter_addr_hold = 40; //SET THIS VAR TO A DEFAULT NUMBER TO AVOID UNDEFINED BEHAVIOUR. THIS NUMBER IS PROBABLY INCORRECT.
+
+
 
      //External IO Configuration Parameters 
 

--- a/extio_technology.cc
+++ b/extio_technology.cc
@@ -268,9 +268,9 @@ int IOTechParam::frequnecy_index(Mem_IO_type type)
 
 IOTechParam::IOTechParam(InputParameter * g_ip) 
 {
-  num_mem_ca  = g_ip->num_mem_dq * ((double)g_ip->num_dq/g_ip->mem_data_width); 
-  num_mem_clk =  g_ip->num_mem_dq *
-                ((double)g_ip->num_dq/g_ip->mem_data_width)/((double)g_ip->num_clk/2); 
+  num_mem_ca  = g_ip->num_mem_dq * (int)(g_ip->num_dq/g_ip->mem_data_width); 
+  num_mem_clk =  (int)(g_ip->num_mem_dq *
+                (g_ip->num_dq/g_ip->mem_data_width)/(g_ip->num_clk/2)); 
 
 
   if (g_ip->io_type == LPDDR2) { //LPDDR
@@ -354,16 +354,16 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
     k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/34 - 1) +
-        0.2*((double)g_ip->num_mem_dq/2 - 1));
+        0.2*(int)(g_ip->num_mem_dq/2 - 1));
     k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/34 - 1) +
-        0.2*((double)g_ip->num_mem_dq/2 - 1));
+        0.2*(int)(g_ip->num_mem_dq/2 - 1));
     k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/100 - 1) +
         0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
 
     t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/34 - 1) +
-        0.3*((double)g_ip->num_mem_dq/2 - 1));
+        0.3*(int)(g_ip->num_mem_dq/2 - 1));
     t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/34 - 1) +
-        0.3*((double)g_ip->num_mem_dq/2 - 1));
+        0.3*(int)(g_ip->num_mem_dq/2 - 1));
     t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/100 - 1) +
         0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
     t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.2*(rtt_ca/100 - 1) +
@@ -483,17 +483,17 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
      k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*((double)g_ip->num_mem_dq/2 - 1));
+         0.2*(int)(g_ip->num_mem_dq/2 - 1));
      k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*((double)g_ip->num_mem_dq/2 - 1));
+         0.2*(int)(g_ip->num_mem_dq/2 - 1));
      k_noise_addr_sen = k_noise_addr * (1 + 0.2*(r_on/50 - 1) + 
          0.2*(num_mem_ca/16 - 1));
 
 
      t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/50 - 1) + 
-         0.3*((double)g_ip->num_mem_dq/2 - 1));
+         0.3*(int)(g_ip->num_mem_dq/2 - 1));
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/50 - 1) + 
-         0.3*((double)g_ip->num_mem_dq/2 - 1));
+         0.3*(int)(g_ip->num_mem_dq/2 - 1));
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.1*(r_on/50 - 1) + 
          0.4*(num_mem_ca/16 - 1));
      t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.1*(r_on/50 - 1) + 
@@ -614,11 +614,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)g_ip->num_mem_dq/2 - 1));
+         0.2*(int)(g_ip->num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)g_ip->num_mem_dq/2 - 1));
+         0.2*(int)(g_ip->num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -626,11 +626,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*((double)g_ip->num_mem_dq/2 - 1));
+         0.3*(int)(g_ip->num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*((double)g_ip->num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*(int)(g_ip->num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -752,11 +752,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)g_ip->num_mem_dq/2 - 1));
+         0.2*(int)(g_ip->num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)g_ip->num_mem_dq/2 - 1));
+         0.2*(int)(g_ip->num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -764,11 +764,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*((double)g_ip->num_mem_dq/2 - 1));
+         0.3*(int)(g_ip->num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*((double)g_ip->num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*(int)(g_ip->num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -876,7 +876,7 @@ IOTechParam::IOTechParam(InputParameter * g_ip)
 
 
    }
-	else
+  else
 	{
 		cout << "Not Yet supported" << endl;
 		exit(1);
@@ -916,8 +916,8 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 						, int num_dq, int connection, int num_loads, double freq) 
 {
   num_mem_ca  = num_mem_dq * (mem_data_width); 
-  num_mem_clk =  num_mem_dq *
-                ((double)num_dq/mem_data_width)/((double)g_ip->num_clk/2); 
+  num_mem_clk =  (int)(num_mem_dq *
+                (num_dq/mem_data_width)/(g_ip->num_clk/2)); 
 
   io_type = io_type1;
   frequency = freq;
@@ -1006,16 +1006,16 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
     k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/34 - 1) +
-        0.2*((double)num_mem_dq/2 - 1));
+        0.2*(int)(num_mem_dq/2 - 1));
     k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/34 - 1) +
-        0.2*((double)num_mem_dq/2 - 1));
+        0.2*(int)(num_mem_dq/2 - 1));
     k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/100 - 1) +
         0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
 
     t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/34 - 1) +
-        0.3*((double)num_mem_dq/2 - 1));
+        0.3*(int)(num_mem_dq/2 - 1));
     t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/34 - 1) +
-        0.3*((double)num_mem_dq/2 - 1));
+        0.3*(int)(num_mem_dq/2 - 1));
     t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/100 - 1) +
         0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
     t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.2*(rtt_ca/100 - 1) +
@@ -1056,7 +1056,7 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
 
   }
-   else if (io_type == WideIO) { //WIDEIO 
+  else if (io_type == WideIO) { //WIDEIO 
      //Technology Parameters
      vdd_io = 1.2;
      v_sw_clk =  1.2;
@@ -1135,17 +1135,17 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
       * of experiments method shown in the technical report (), in Chapter 2.2. */
 
      k_noise_write_sen = k_noise_write * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*((double)num_mem_dq/2 - 1));
+         0.2*(int)(num_mem_dq/2 - 1));
      k_noise_read_sen = k_noise_read * (1 + 0.2*(r_on/50 - 1) + 
-         0.2*((double)num_mem_dq/2 - 1));
+         0.2*(int)(num_mem_dq/2 - 1));
      k_noise_addr_sen = k_noise_addr * (1 + 0.2*(r_on/50 - 1) + 
          0.2*(num_mem_ca/16 - 1));
 
 
      t_jitter_setup_sen = t_jitter_setup * (1  + 0.1*(r_on/50 - 1) + 
-         0.3*((double)num_mem_dq/2 - 1));
+         0.3*(int)(num_mem_dq/2 - 1));
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.1*(r_on/50 - 1) + 
-         0.3*((double)num_mem_dq/2 - 1));
+         0.3*(int)(num_mem_dq/2 - 1));
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.1*(r_on/50 - 1) + 
          0.4*(num_mem_ca/16 - 1));
      t_jitter_addr_hold_sen = t_jitter_addr_hold * (1 + 0.1*(r_on/50 - 1) + 
@@ -1294,11 +1294,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)num_mem_dq/2 - 1));
+         0.2*(int)(num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)num_mem_dq/2 - 1));
+         0.2*(int)(num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -1306,11 +1306,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*((double)num_mem_dq/2 - 1));
+         0.3*(int)(num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*((double)num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*(int)(num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -1349,7 +1349,7 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
 
    }
-   else if (io_type == DDR4)
+  else if (io_type == DDR4)
    { //Default parameters for DDR4
      // IO Supply voltage (V) 
      vdd_io = 1.2;
@@ -1459,11 +1459,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      k_noise_write_sen = k_noise_write * (1 + 0.1*(rtt1_dq_write/60 - 1) +
          0.2*(rtt2_dq_write/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)num_mem_dq/2 - 1));
+         0.2*(int)(num_mem_dq/2 - 1));
 
      k_noise_read_sen = k_noise_read * (1 + 0.1*(rtt1_dq_read/60 - 1) +
          0.2*(rtt2_dq_read/60 - 1) + 0.2*(r_on/34 - 1) +
-         0.2*((double)num_mem_dq/2 - 1));
+         0.2*(int)(num_mem_dq/2 - 1));
 
      k_noise_addr_sen = k_noise_addr * (1 + 0.1*(rtt_ca/50 - 1) +
          0.2*(r_on/34 - 1) + 0.2*(num_mem_ca/16 - 1));
@@ -1471,11 +1471,11 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
      t_jitter_setup_sen = t_jitter_setup * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 0.1*(r_on/34 - 1) + 
-         0.3*((double)num_mem_dq/2 - 1));
+         0.3*(int)(num_mem_dq/2 - 1));
 
      t_jitter_hold_sen = t_jitter_hold * (1 + 0.2*(rtt1_dq_write/60 - 1) + 
          0.3*(rtt2_dq_write/60 - 1) + 
-         0.1*(r_on/34 - 1) + 0.3*((double)num_mem_dq/2 - 1));
+         0.1*(r_on/34 - 1) + 0.3*(int)(num_mem_dq/2 - 1));
 
      t_jitter_addr_setup_sen = t_jitter_addr_setup * (1 + 0.2*(rtt_ca/50 - 1) + 
          0.1*(r_on/34 - 1) + 0.4*(num_mem_ca/16 - 1));
@@ -1585,7 +1585,7 @@ IOTechParam::IOTechParam(InputParameter * g_ip, Mem_IO_type io_type1, int num_me
 
 
    }
-	else
+  else
 	{
 		cout << "Not Yet supported" << endl;
 		exit(1);

--- a/io.cc
+++ b/io.cc
@@ -2733,7 +2733,7 @@ void output_UCA(uca_org_t *fr)
 	if(g_ip->is_3d_mem)
 	{
 
-		cout<<"-------  CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"."VER_COMMENT_CACTI
+		cout<<"-------  CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"." VER_COMMENT_CACTI
 								<< " of " << VER_UPDATE_CACTI << ") 3D DRAM Main Memory  -------"<<endl;
 
 		cout << "\nMemory Parameters:\n";
@@ -2810,17 +2810,17 @@ void output_UCA(uca_org_t *fr)
   }
   else {
     if (g_ip->data_arr_ram_cell_tech_type == 3) {
-      cout << "\n---------- CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"."VER_COMMENT_CACTI
+      cout << "\n---------- CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"." VER_COMMENT_CACTI
 								<< " of " << VER_UPDATE_CACTI << "), Uniform Cache Access " <<
         "Logic Process Based DRAM Model ----------\n";
     }
     else if (g_ip->data_arr_ram_cell_tech_type == 4) {
-      cout << "\n---------- CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"."VER_COMMENT_CACTI
+      cout << "\n---------- CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"." VER_COMMENT_CACTI
 								<< " of " << VER_UPDATE_CACTI << "), Uniform" <<
         "Cache Access Commodity DRAM Model ----------\n";
     }
     else {
-      cout << "\n---------- CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"."VER_COMMENT_CACTI
+      cout << "\n---------- CACTI (version "<< VER_MAJOR_CACTI <<"."<< VER_MINOR_CACTI<<"." VER_COMMENT_CACTI
 								<< " of " << VER_UPDATE_CACTI << "), Uniform Cache Access "
         "SRAM Model ----------\n";
     }

--- a/memcad.cc
+++ b/memcad.cc
@@ -163,7 +163,7 @@ void find_all_channels(MemCadParameters * memcad_params)
 					}
 				}
 				
-				if( (current_dimm_model== JUST_RDIMM) || (current_dimm_model== ALL)
+				if( ((current_dimm_model== JUST_RDIMM) || (current_dimm_model== ALL))
 				&&  ((d1==0) || (MemoryParameters::cost[current_io_type][1][d1-1]<INF))
 				&&  ((d2==0) || (MemoryParameters::cost[current_io_type][1][d2-1]<INF))
 				&&  ((d3==0) || (MemoryParameters::cost[current_io_type][1][d3-1]<INF)) )				
@@ -200,7 +200,7 @@ void find_all_channels(MemCadParameters * memcad_params)
 					}
 				}
 				
-				if( (current_dimm_model== JUST_UDIMM) || (current_dimm_model== ALL)
+				if( ((current_dimm_model== JUST_UDIMM) || (current_dimm_model== ALL))
 				&&  ((d1==0) || (MemoryParameters::cost[current_io_type][0][d1-1]<INF))
 				&&  ((d2==0) || (MemoryParameters::cost[current_io_type][0][d2-1]<INF))
 				&&  ((d3==0) || (MemoryParameters::cost[current_io_type][0][d3-1]<INF)) )				
@@ -233,7 +233,6 @@ void find_all_channels(MemCadParameters * memcad_params)
 						}
 					}
 				}
-								
 			}
 		}
 	}
@@ -391,9 +390,13 @@ void find_all_bobs(MemCadParameters * memcad_params)
 	else if(memcad_params->same_bw_in_bob)
 	{
 		sort(memcad_all_channels->begin(), memcad_all_channels->end(), compare_channels_bw); 
-		vector<int> start_index; start_index.push_back(0);
+		vector<int> start_index; 
 		vector<int> end_index;
-		int last_bw =(*memcad_all_channels)[0]->bandwidth;
+		int last_bw = 0;
+		if(memcad_all_channels->size() > 0){
+			start_index.push_back(0);
+			last_bw =(*memcad_all_channels)[0]->bandwidth;
+		}
 		for(unsigned int i=0;i< memcad_all_channels->size();i++)
 		{
 			if(last_bw!=(*memcad_all_channels)[i]->bandwidth)

--- a/parameter.cc
+++ b/parameter.cc
@@ -1621,15 +1621,15 @@ DynamicParameter::init_CAM()
 
   // calculate wire parameters
 
-  double c_b_metal = cell.h * wire_local.C_per_um;
+  //double c_b_metal = cell.h * wire_local.C_per_um;
 //  double C_bl;
 
-  c_b_metal = cam_cell.h * wire_local.C_per_um;//IBM and SUN design, SRAM array uses dummy cells to fill the blank space due to mismatch on CAM-RAM
+  //c_b_metal = cam_cell.h * wire_local.C_per_um;//IBM and SUN design, SRAM array uses dummy cells to fill the blank space due to mismatch on CAM-RAM
   V_b_sense = (0.05 * g_tp.sram_cell.Vdd > VBITSENSEMIN) ? 0.05 * g_tp.sram_cell.Vdd : VBITSENSEMIN;
   deg_bl_muxing = 1;//FA fix as 1
   // "/ 2.0" below is due to the fact that two adjacent access transistors share drain
   // contacts in a physical layout
-  double Cbitrow_drain_cap = drain_C_(g_tp.cam.cell_a_w, NCH, 1, 0, cam_cell.w, false, true) / 2.0;//TODO: comment out these two lines
+  //double Cbitrow_drain_cap = drain_C_(g_tp.cam.cell_a_w, NCH, 1, 0, cam_cell.w, false, true) / 2.0;//TODO: comment out these two lines
 //  C_bl = num_r_subarray * (Cbitrow_drain_cap + c_b_metal);
   dram_refresh_period = 0;
 
@@ -1782,15 +1782,15 @@ DynamicParameter::init_FA()
   cell.w = g_tp.sram.b_w + 2 * wire_local.pitch * (g_ip->num_rw_ports -1 + (g_ip->num_rd_ports - g_ip->num_se_rd_ports)
       + g_ip->num_wr_ports) + g_tp.wire_local.pitch * g_ip->num_se_rd_ports + 2 * wire_local.pitch*(g_ip->num_search_ports-1);
 
-  double c_b_metal = cell.h * wire_local.C_per_um;
+  //double c_b_metal = cell.h * wire_local.C_per_um;
   //  double C_bl;
 
-  c_b_metal = cam_cell.h * wire_local.C_per_um;//IBM and SUN design, SRAM array uses dummy cells to fill the blank space due to mismatch on CAM-RAM
+  //c_b_metal = cam_cell.h * wire_local.C_per_um;//IBM and SUN design, SRAM array uses dummy cells to fill the blank space due to mismatch on CAM-RAM
   V_b_sense = (0.05 * g_tp.sram_cell.Vdd > VBITSENSEMIN) ? 0.05 * g_tp.sram_cell.Vdd : VBITSENSEMIN;
   deg_bl_muxing = 1;//FA fix as 1
   // "/ 2.0" below is due to the fact that two adjacent access transistors share drain
   // contacts in a physical layout
-  double Cbitrow_drain_cap = drain_C_(g_tp.cam.cell_a_w, NCH, 1, 0, cam_cell.w, false, true) / 2.0;//TODO: comment out these two lines
+  //double Cbitrow_drain_cap = drain_C_(g_tp.cam.cell_a_w, NCH, 1, 0, cam_cell.w, false, true) / 2.0;//TODO: comment out these two lines
   //	  C_bl = num_r_subarray * (Cbitrow_drain_cap + c_b_metal);
   dram_refresh_period = 0;
 


### PR DESCRIPTION
- Added explicit type casting to avoid int division, thus losing precision. This fixes floating point arithmetic crashes.
- Commented out unused variables
- Added spaces between a quote and the Macro
- Added brackets for conditions, because of the && to || precedence, the conditions were probably incorrect.